### PR TITLE
Add molecule-idempotence-notest tag to the cache update task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,5 +19,7 @@
       apt:
         force_apt_get: yes
         update_cache: yes
+      tags:
+        - molecule-idempotence-notest
   when:
     - ansible_distribution == "Debian"


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds the `molecule-idempotence-notest` tag to the cache update task.

## 💭 Motivation and Context ##

If a package happens to update after the converge playbook but before the idempotence check then this task could cause that check to fail.

I saw this happen in [this GitHub Actions run](https://github.com/cisagov/ansible-role-domain-manager/pull/15/checks?check_run_id=1499445571).

## 🧪 Testing ##

All pre-commit hooks and molecule tests pass.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
