### PR TITLE
Remove Jinja2 Templating Delimiters from Conditional Statement

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,4 +23,4 @@
         update_cache: yes
       tags:
         - molecule-idempotence-notest
-  when: ansible_distribution_release in {{ supported_releases | default([]) }}
+  when: ansible_distribution_release in supported_releases | default([])


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

When I wrote #4 I did not notice the following warning it was generating in testing;
`Warning: : conditional statements should not include jinja2 templating`

This was noticed elsewhere by @jsf9k, and he created #6 to track the problem. I looked into it and it's a simple enough fix, so I have removed the delimiters and confirmed functionality with no warnings.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Resolve #6 because we don't like warnings.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated testing passes *and* generates no warnings.
<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
