### PR TITLE
Remove support for Buster and add support for Trixie

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -23,7 +23,7 @@ def test_backports(host):
     # The backports package repo should be present for any Debian or Ubuntu
     # release other than those found in unsupported_releases.
     if distribution in supported_distributions:
-        cmd = host.run("apt-cache policy")
+        cmd = host.run("apt update")
         assert cmd.rc == 0
 
         if codename not in unsupported_releases:

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -17,11 +17,11 @@ def test_backports(host):
     codename = host.system_info.codename
 
     supported_distributions = ["debian", "ubuntu"]
-    # Trixie does not yet have a backports package repo.
-    unsupported_releases = ["trixie"]
+    # Buster no longer has a backports package repo.
+    unsupported_releases = ["buster"]
 
     # The backports package repo should be present for any Debian or Ubuntu
-    # release other than those found in `unsupported_releases`.
+    # release other than those found in unsupported_releases.
     if distribution in supported_distributions:
         cmd = host.run("apt-cache policy")
         assert cmd.rc == 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Load var file with package names based on the OS type
+- name: Load var file with default values based on the OS type
   ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
   vars:
     params:
@@ -11,16 +11,27 @@
       paths:
         - "{{ role_path }}/vars"
 
-- name: Add backports repository and update the package cache
+- name: Add backports repository
   when: ansible_distribution_release in supported_releases | default([])
   block:
-    - name: Add backports repository
+    - name: Add backports repository (pre-Bookworm)
+      when: ansible_distribution_release not in ["bookworm", "trixie"]
       ansible.builtin.apt_repository:
         repo: "{{ source_list_entry | format(ansible_distribution_release) }}"
-
-    - name: Update the package cache
-      ansible.builtin.apt:
-        force_apt_get: true
-        update_cache: true
-      tags:
-        - molecule-idempotence-notest
+    - name: Add backports repository (Bookworm and later)
+      when: ansible_distribution_release in ["bookworm", "trixie"]
+      block:
+        - name: Install a required prerequisite
+          ansible.builtin.package:
+            name:
+              - python3-debian
+        - name: Add backports repository
+          ansible.builtin.deb822_repository:
+            components:
+              - main
+            name: backports
+            signed_by: /usr/share/keyrings/debian-archive-keyring.gpg
+            suites:
+              - "{{ ansible_distribution_release }}-backports"
+            uris:
+              - http://deb.debian.org/debian

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -3,6 +3,6 @@ source_list_entry: "deb http://deb.debian.org/debian %s-backports main"
 
 # The Debian releases that have backports repositories
 supported_releases:
-  - buster
   - bullseye
   - bookworm
+  - trixie


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes support for Buster and adds support for Trixie.  This is being done because the `buster-backports` package repository was removed and the `trixie-backports` package repository was added upstream over the weekend.

## 💭 Motivation and context ##

This Ansible role is currently failing its tests, so it must be fixed.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.