### PR TITLE
Add an option to update the package cache after adding the backports repository

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,6 +194,7 @@ jobs:
           - ubuntu-24-systemd
         scenario:
           - default
+          - update_cache
     steps:
       - id: harden-runner
         name: Harden the runner

--- a/README.md
+++ b/README.md
@@ -13,14 +13,9 @@ None.
 
 ## Role Variables ##
 
-None.
-
-<!--
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
-| optional_variable | Describe its purpose. | `default_value` | No |
-| required_variable | Describe its purpose. | n/a | Yes |
--->
+| backports_update_cache | Indicate if the package cache should be updated after adding the backports repository. | `false` | No |
 
 ## Dependencies ##
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ None.
 
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
-| backports_update_cache | Indicate if the package cache should be updated after adding the backports repository. | `false` | No |
+| backports_update_cache | Indicate if the package cache should be updated after adding the backports repository. | `true` | No |
 
 ## Dependencies ##
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # Indicate if the package cache should be updated after adding the backports repository
-backports_update_cache: false
+backports_update_cache: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# Indicate if the package cache should be updated after adding the backports repository
+backports_update_cache: false

--- a/molecule/update_cache/INSTALL.rst
+++ b/molecule/update_cache/INSTALL.rst
@@ -1,0 +1,1 @@
+../default/INSTALL.rst

--- a/molecule/update_cache/converge.yml
+++ b/molecule/update_cache/converge.yml
@@ -6,4 +6,4 @@
       ansible.builtin.include_role:
         name: ansible-role-backports
       vars:
-        backports_update_cache: true
+        backports_update_cache: false

--- a/molecule/update_cache/converge.yml
+++ b/molecule/update_cache/converge.yml
@@ -1,0 +1,9 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: Include ansible-role-backports
+      ansible.builtin.include_role:
+        name: ansible-role-backports
+      vars:
+        backports_update_cache: true

--- a/molecule/update_cache/externally-managed-python.yml
+++ b/molecule/update_cache/externally-managed-python.yml
@@ -1,0 +1,1 @@
+../default/externally-managed-python.yml

--- a/molecule/update_cache/molecule.yml
+++ b/molecule/update_cache/molecule.yml
@@ -1,0 +1,208 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-amazonlinux2023-ansible:latest
+    name: amazonlinux2023-systemd-amd64
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-amazonlinux2023-ansible:latest
+    name: amazonlinux2023-systemd-arm64
+    platform: arm64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-debian10-ansible:latest
+    name: debian10-systemd-amd64
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-debian10-ansible:latest
+    name: debian10-systemd-arm64
+    platform: arm64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-debian11-ansible:latest
+    name: debian11-systemd-amd64
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-debian11-ansible:latest
+    name: debian11-systemd-arm64
+    platform: arm64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-debian12-ansible:latest
+    name: debian12-systemd-amd64
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-debian12-ansible:latest
+    name: debian12-systemd-arm64
+    platform: arm64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/cisagov/docker-debian13-ansible:latest
+    name: debian13-systemd-amd64
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/cisagov/docker-debian13-ansible:latest
+    name: debian13-systemd-arm64
+    platform: arm64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/cisagov/docker-kali-ansible:latest
+    name: kali-systemd-amd64
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/cisagov/docker-kali-ansible:latest
+    name: kali-systemd-arm64
+    platform: arm64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-fedora39-ansible:latest
+    name: fedora39-systemd-amd64
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-fedora39-ansible:latest
+    name: fedora39-systemd-arm64
+    platform: arm64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-fedora40-ansible:latest
+    name: fedora40-systemd-amd64
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-fedora40-ansible:latest
+    name: fedora40-systemd-arm64
+    platform: arm64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-ubuntu2004-ansible:latest
+    name: ubuntu-20-systemd-amd64
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-ubuntu2004-ansible:latest
+    name: ubuntu-20-systemd-arm64
+    platform: arm64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-ubuntu2204-ansible:latest
+    name: ubuntu-22-systemd-amd64
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-ubuntu2204-ansible:latest
+    name: ubuntu-22-systemd-arm64
+    platform: arm64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-ubuntu2404-ansible:latest
+    name: ubuntu-24-systemd-amd64
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-ubuntu2404-ansible:latest
+    name: ubuntu-24-systemd-arm64
+    platform: arm64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+scenario:
+  name: update_cache
+verifier:
+  name: testinfra

--- a/molecule/update_cache/prepare.yml
+++ b/molecule/update_cache/prepare.yml
@@ -1,0 +1,1 @@
+../default/prepare.yml

--- a/molecule/update_cache/requirements.yml
+++ b/molecule/update_cache/requirements.yml
@@ -1,0 +1,1 @@
+../default/requirements.yml

--- a/molecule/update_cache/templates/EXTERNALLY-MANAGED.j2
+++ b/molecule/update_cache/templates/EXTERNALLY-MANAGED.j2
@@ -1,0 +1,1 @@
+../../default/templates/EXTERNALLY-MANAGED.j2

--- a/molecule/update_cache/tests/test_default.py
+++ b/molecule/update_cache/tests/test_default.py
@@ -1,0 +1,1 @@
+../../default/tests/test_default.py

--- a/molecule/update_cache/upgrade.yml
+++ b/molecule/update_cache/upgrade.yml
@@ -1,0 +1,1 @@
+../default/upgrade.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,7 +47,6 @@
 
         - name: Update the package cache
           ansible.builtin.apt:
-            force_apt_get: true
             update_cache: true
           when:
             - add_backports_repo.changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,6 +21,7 @@
     - name: Add backports repository (pre-Bookworm)
       when: ansible_distribution_release not in ["bookworm", "trixie"]
       ansible.builtin.apt_repository:
+        filename: backports
         repo: "{{ source_list_entry | format(ansible_distribution_release) }}"
         update_cache: "{{ backports_update_cache }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,3 +39,11 @@
               - "{{ ansible_distribution_release }}-backports"
             uris:
               - http://deb.debian.org/debian
+
+    - name: Update the package cache
+      ansible.builtin.apt:
+        force_apt_get: true
+        update_cache: true
+      tags:
+        - molecule-idempotence-notest
+      when: backports_update_cache

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,6 +22,8 @@
       when: ansible_distribution_release not in ["bookworm", "trixie"]
       ansible.builtin.apt_repository:
         repo: "{{ source_list_entry | format(ansible_distribution_release) }}"
+        update_cache: "{{ backports_update_cache }}"
+
     - name: Add backports repository (Bookworm and later)
       when: ansible_distribution_release in ["bookworm", "trixie"]
       block:
@@ -29,6 +31,7 @@
           ansible.builtin.package:
             name:
               - python3-debian
+
         - name: Add backports repository
           ansible.builtin.deb822_repository:
             components:
@@ -39,11 +42,12 @@
               - "{{ ansible_distribution_release }}-backports"
             uris:
               - http://deb.debian.org/debian
+          register: add_backports_repo
 
-    - name: Update the package cache
-      ansible.builtin.apt:
-        force_apt_get: true
-        update_cache: true
-      tags:
-        - molecule-idempotence-notest
-      when: backports_update_cache
+        - name: Update the package cache
+          ansible.builtin.apt:
+            force_apt_get: true
+            update_cache: true
+          when:
+            - add_backports_repo.changed
+            - backports_update_cache


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request does the following:
- Adds a variable to indicate if the package cache should be updated after adding the backports repository on supported platforms.
- Adds a new molecule scenario to test that the above works as intended.
- Specifies a filename for the `ansible.builtin.apt_repository` task that matches the one used by the `ansible.builtin.deb822_repository` task.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Prior to #41 the role would update the package cache after adding a backports repository. This pull request restores that functionality but allows the option to skip updating the package cache by setting `backports_update_cache` to `false`. This will allow consuming roles or playbooks to indicate a package cache update without needing to explicitly declare a task to do so.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
