### PR TITLE
Do nothing on Ubuntu targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@
 
 This Ansible role adds the [backports](https://backports.debian.org/)
 [package repositories](https://backports.debian.org/Instructions/) for
-supported Debian releases.  It does the same for
-[Ubuntu backports](https://help.ubuntu.com/community/UbuntuBackports) with
-supported releases.
+supported Debian releases.
 
 ## Requirements ##
 

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -16,7 +16,7 @@ def test_backports(host):
     distribution = host.system_info.distribution
     codename = host.system_info.codename
 
-    supported_distributions = ["debian", "ubuntu"]
+    supported_distributions = ["debian"]
     # Buster no longer has a backports package repo.
     unsupported_releases = ["buster"]
 

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -1,9 +1,1 @@
----
-source_list_entry: "deb http://archive.ubuntu.com/ubuntu %s-backports main
-  restricted universe multiverse"
-
-# The Ubuntu releases that have backports repositories
-supported_releases:
-  - focal
-  - jammy
-  - noble
+Default.yml

--- a/vars/Ubuntu_aarch64.yml
+++ b/vars/Ubuntu_aarch64.yml
@@ -1,9 +1,0 @@
----
-source_list_entry: "deb http://ports.ubuntu.com/ubuntu-ports %s-backports main
-  restricted universe multiverse"
-
-# The Ubuntu releases that have backports repositories
-supported_releases:
-  - focal
-  - jammy
-  - noble


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the role to do nothing on Ubuntu targets.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Ubuntu (at least all versions we support) ships with the [Ubuntu Backports](https://help.ubuntu.com/community/UbuntuBackports) already added as a repository in the default configuration. There's no reason to write _another_ configuration to add this repository.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I also verified that an uncommented backports repository is listed in every version of Ubuntu we supported (and in the soon to be supported Ubuntu Noble Numbat):

```console
$ for release in focal jammy noble; do echo Ubuntu "$release"; docker run --rm ubuntu:"$release" grep -rin "$release-backports" /etc/apt/; done
Ubuntu focal
/etc/apt/sources.list:34:deb http://archive.ubuntu.com/ubuntu/ focal-backports main restricted universe multiverse
/etc/apt/sources.list:35:# deb-src http://archive.ubuntu.com/ubuntu/ focal-backports main restricted universe multiverse
Ubuntu jammy
/etc/apt/sources.list:34:deb http://archive.ubuntu.com/ubuntu/ jammy-backports main restricted universe multiverse
/etc/apt/sources.list:35:# deb-src http://archive.ubuntu.com/ubuntu/ jammy-backports main restricted universe multiverse
Ubuntu noble
/etc/apt/sources.list.d/ubuntu.sources:34:Suites: noble noble-updates noble-backports
$ for release in focal jammy noble; do echo Ubuntu "$release"; docker run --platform arm64 --rm ubuntu:"$release" grep -rin "$release-backports" /etc/apt/; done
Ubuntu focal
/etc/apt/sources.list:34:deb http://ports.ubuntu.com/ubuntu-ports/ focal-backports main restricted universe multiverse
/etc/apt/sources.list:35:# deb-src http://ports.ubuntu.com/ubuntu-ports/ focal-backports main restricted universe multiverse
Ubuntu jammy
/etc/apt/sources.list:34:deb http://ports.ubuntu.com/ubuntu-ports/ jammy-backports main restricted universe multiverse
/etc/apt/sources.list:35:# deb-src http://ports.ubuntu.com/ubuntu-ports/ jammy-backports main restricted universe multiverse
Ubuntu noble
/etc/apt/sources.list.d/ubuntu.sources:34:Suites: noble noble-updates noble-backports
```

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
